### PR TITLE
Fix CommonJS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add react-flickity-component
 
 ```javascript
 // Commonjs
-const Flickity = require('flickity');
+const Flickity = require('react-flickity-component');
 // Or for ES2015 module
 import Flickity from 'react-flickity-component'
 


### PR DESCRIPTION
I think the CommonJS example uses the wrong module name?