### PR TITLE
Adding children properties on index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ interface Props {
   options?: FlickityOptions;
   reloadOnUpdate?: boolean;
   static?: boolean;
+  children?: React.ReactNode;
 }
 
 declare class Flickity extends React.Component<Props, any> {


### PR DESCRIPTION
Updating the index.d.ts so it won't throw any error when the flickity is used that have a children. I'm using children as optional because the children itself might be null. Might need change if it is really needed