### PR TITLE
[type]: fix 'initialIndex' type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,9 +55,9 @@ export interface FlickityOptions {
     cellSelector?: string;
 
     /**
-     * Zero-based index of the initial selected cell.
+     * Zero-based index or selector string of the initial selected cell.
      */
-    initialIndex?: number;
+    initialIndex?: number | string | undefined;
 
     /**
      * Enable keyboard navigation. Users can tab to a Flickity gallery, and pressing left & right keys to change cells.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -57,7 +57,7 @@ export interface FlickityOptions {
     /**
      * Zero-based index or selector string of the initial selected cell.
      */
-    initialIndex?: number | string | undefined;
+    initialIndex?: number | string;
 
     /**
      * Enable keyboard navigation. Users can tab to a Flickity gallery, and pressing left & right keys to change cells.
@@ -178,7 +178,7 @@ export interface FlickityOptions {
      * 
      * default: false
      */
-     pauseAutoPlayOnHover?:boolean;
+     pauseAutoPlayOnHover?: boolean;
 
     /**
      * Changes height of carousel to fit height of selected slide.


### PR DESCRIPTION
fix type incompatibility between 'flickity' and 'react-flickity-component'
[ref](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/flickity/index.d.ts#L95)