### PR TITLE
bug: prevent crashes on hydration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ class FlickityComponent extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (!this.flkty) return;
     const {
       children,
       options: { draggable, initialIndex },
@@ -39,7 +40,6 @@ class FlickityComponent extends Component {
     } = this.props;
     const { flickityReady } = this.state;
     if (reloadOnUpdate || (!prevState.flickityReady && flickityReady)) {
-      if (!this.flkty) return;
       const isActive = this.flkty.isActive;
       this.flkty.deactivate();
       this.flkty.selectedIndex = initialIndex || 0;
@@ -61,7 +61,7 @@ class FlickityComponent extends Component {
   }
 
   async componentDidMount() {
-    if (!canUseDOM) return null;
+    if (!canUseDOM || !this.carousel) return null;
     const Flickity = (await import('flickity')).default;
     const { flickityRef, options } = this.props;
     this.flkty = new Flickity(this.carousel, options);


### PR DESCRIPTION
On certain cases with SSR'd pages (i.e. Next.js), if we have some hydration issues, the Flickity component may first (or intermediately) render null, while still calling `componentDidMount` and `componentDidUpdate`.

Without a valid node, the app crashes trying to instantiate Flickity on null:
<img width="1240" alt="Screenshot 2023-06-01 at 12 24 39" src="https://github.com/yaodingyd/react-flickity-component/assets/802086/d8d63fa5-a879-4022-9073-39ad76911e4c">

This patch fixes that, by ensuring that `this.carousel` exists before trying to instantiate Flickity with it, ensuring that `this.flkty` exists before trying to access it.