### PR TITLE
Patch package.json to fix TS type exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./dist/react-flickity-component.umd.js",
   "module": "./dist/react-flickity-component.es.js",
   "exports": {
-    ".":  {
+    ".": {
       "types": "./src/index.d.ts",
       "import": "./dist/react-flickity-component.es.js",
       "require": "./dist/react-flickity-component.umd.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flickity-component",
-  "version": "4.0.7",
+  "version": "4.0.6",
   "description": "react flickity component",
   "files": [
     "dist",
@@ -9,15 +9,10 @@
   "main": "./dist/react-flickity-component.umd.js",
   "module": "./dist/react-flickity-component.es.js",
   "exports": {
-    ".": {
-      "import": {
-        "default": "./dist/react-flickity-component.es.js",
-        "types": "./src/index.d.ts"
-      },
-      "require": {
-        "default": "./dist/react-flickity-component.umd.js",
-        "types": "./src/index.f.ts"
-      }
+    ".":  {
+      "types": "./src/index.d.ts",
+      "import": "./dist/react-flickity-component.es.js",
+      "require": "./dist/react-flickity-component.umd.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flickity-component",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "react flickity component",
   "files": [
     "dist",
@@ -10,8 +10,14 @@
   "module": "./dist/react-flickity-component.es.js",
   "exports": {
     ".": {
-      "import": "./dist/react-flickity-component.es.js",
-      "require": "./dist/react-flickity-component.umd.js"
+      "import": {
+        "default": "./dist/react-flickity-component.es.js",
+        "types": "./src/index.d.ts"
+      },
+      "require": {
+        "default": "./dist/react-flickity-component.umd.js",
+        "types": "./src/index.f.ts"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
I was running into this error (https://github.com/yaodingyd/react-flickity-component/issues/149) reported by @minhquan1313, which relates to TS being unable to find the declaration types for the library.

This PR fixes this by specifically pointing to the types file `"./src/index.d.ts"`

Tested by altering the package.json in `node_modules` with my proposed fix, and the types are pulled in correctly now :)